### PR TITLE
Checkbox issues

### DIFF
--- a/block.js
+++ b/block.js
@@ -422,7 +422,10 @@ var SirTrevorBlock = function(title, type) {
         var $element = $('<input>', {
           type: 'checkbox',
           name: name,
-          checked: (value ? value : component.default),
+          /** If the checkbox has never been set before then the value field will be the empty string, in which case we
+          use the default value. This could in theory be any string, so we'll decide that 'false' is false and anything
+          else is true. If the checkbox has previously been set, its value will be a boolean so we can safely use that. **/
+          checked: (value === '') ? ((component.default === 'false') ? false : true) : value,
           class: component.class
         });
 


### PR DESCRIPTION
Checkboxes now respect their default values (a default value of 'false' will cause boxes to default to unchecked; anything else will cause them to default to checked). Checkboxes also now correctly load in their values, which were previously being saved correctly but not loaded thereafter.
